### PR TITLE
Lab 5 Ex3 wizard text not accurate

### DIFF
--- a/Instructions/Labs/LAB_AK_05_Lab1_Ex2_Insider_Risk.md
+++ b/Instructions/Labs/LAB_AK_05_Lab1_Ex2_Insider_Risk.md
@@ -152,7 +152,7 @@ In this task, you will configure a policy named 'Financial Data Protection' in M
 
 1. Select **Next**.
 
-1. On the **Triggering thresholds for this policy** page select **Use default thresholds (Recommended)** then select **Next**.
+1. On the **Choose thresholds for triggering events** page select **Apply built-in thresholds (recommended)** then select **Next**.
 
 1. On the **Indicators** page, select the drop down for **Physical access indicators** and deselect **Physical access after termination or failed access to sensitive asset** if selected then select **Next**.
 


### PR DESCRIPTION
![Lab5Ex3update](https://github.com/kramit/SC-400T00A-Microsoft-Information-Protection-Administrator/assets/5239228/d77acac1-c1da-486b-a495-1cf3703bc4a9)


The wizard at this step now states the following

1. On the **Choose thresholds for triggering events** page select **Apply built-in thresholds (recommended)** then select **Next**.


not 

Triggering thresholds for this policy page select Use default thresholds (Recommended)

Image attached from the go deploy lab partner platform to show lab inaccuracy https://www.godeploy.com 

# Module: 
## Lab/Demo: 5
Fixes # .

Changes proposed in this pull request:

Change text to reflect the wizard text as of 31/10/2023

-
-
-